### PR TITLE
Hand arguments from start_nf.sh over to run_Wochenende.py through nf_wochenende.nf

### DIFF
--- a/nf_wochenende.nf
+++ b/nf_wochenende.nf
@@ -180,14 +180,22 @@ process wochenende {
     print params.metagenome
     print params.WOCHENENDE_DIR
 
+    if (params.mapping_quality != "") {
+       params.mq = "--" + params.mapping_quality
+       print params.mq
+    } else {
+       params.mq = ""
+    }
+
     """
     export WOCHENENDE_DIR=${params.WOCHENENDE_DIR}
     export HAYBALER_DIR=${params.HAYBALER_DIR}
 
     cp ${params.WOCHENENDE_DIR}/get_wochenende.sh .
-    bash get_wochenende.sh 
+    bash get_wochenende.sh
+        
 
-    python3 run_Wochenende.py --metagenome ${params.metagenome} --threads $task.cpus --aligner $params.aligner $params.abra $params.mapping_quality $params.mismatches --readType $params.readType $params.no_prinseq --debug --force_restart $fastq
+    python3 run_Wochenende.py --metagenome ${params.metagenome} --threads $task.cpus --aligner $params.aligner $params.abra $params.mq --remove_mismatching $params.mismatches --readType $params.readType $params.no_prinseq --debug --force_restart $fastq
 
     """
 

--- a/start_nf.sh
+++ b/start_nf.sh
@@ -13,7 +13,7 @@ cp test/data/*.fastq . && bwa index test/data/ref.fa
 # run pipeline, no bash variables allowed as empty strings evaluate to true in groovy
 #nextflow run nf_wochenende.nf  -with-timeline -with-report -with-dag flowchart.dot --metagenome Ath --aligner minimap2long --remove_mismatching 250 --mq30 --readType SE --longread --no_dup_removal --no_abra --fastq test_sm.fastq
 # run test
-nextflow run nf_wochenende.nf  -with-timeline -with-report --metagenome testdb --aligner bwamem --remove_mismatching 2 --mq30 --readType PE  --no_dup_removal --no_abra --fastq *R1.fastq
+nextflow run nf_wochenende.nf  -with-timeline -with-report --metagenome testdb --aligner bwamem --mismatches 2 --mapping_quality mq30 --readType PE  --no_dup_removal --no_abra --fastq *R1.fastq
 
 
 # python3 /run_Wochenende.py --ref  --threads 16 --aligner minimap2-long   250 SE  --debug --force_restart test_sm.fastq


### PR DESCRIPTION
Some arguments weren't passed from `start_nf.sh` to `nf_wochenende.nf` to `run_Wochenende.py`. Mapping quality and mismatches are now handed over. Others will follow: params.aligner and params.no_prinseq are still empty